### PR TITLE
use eqReq to compare JSStrings

### DIFF
--- a/src/Francium/Components/Form/Input.hs
+++ b/src/Francium/Components/Form/Input.hs
@@ -25,8 +25,8 @@ instance Component Input where
        reactimate
          (fmap (\(v,el) ->
                   let htmlInput = castToHTMLInputElement el
-                  in do now <- htmlInputElementGetValue htmlInput
-                        when (now /= v)
+                  in do now <- (htmlInputElementGetValue htmlInput :: IO JSString)
+                        when (not (eqRef v now))
                              (htmlInputElementSetValue htmlInput v))
                ((,) <$> inputValue <@> onRender))
        return Instantiation {outputs =


### PR DESCRIPTION
Fixes a build problem where no `Eq` instance is available for `JSString`, similar to https://github.com/ocharles/virtual-dom/issues/4
